### PR TITLE
remove promise hack

### DIFF
--- a/packages/otel-exporter-jaeger/src/index.ts
+++ b/packages/otel-exporter-jaeger/src/index.ts
@@ -38,23 +38,7 @@ export const makeJaegerTracingSpanExporter = M.gen(function* (_) {
   const spanExporter = yield* _(
     pipe(
       T.succeedWith(() => new JaegerExporter(config)),
-      M.make((p) =>
-        // NOTE Unfortunately this workaround/"hack" is currently needed since Otel doesn't yet provide a graceful
-        // way to shutdown.
-        //
-        // Related issue: https://github.com/open-telemetry/opentelemetry-js/issues/987
-        pipe(
-          T.sleep(2_000),
-          T.zipRight(T.promise(() => p.shutdown())),
-          T.zipRight(
-            T.effectAsync<unknown, never, void>((cb) => {
-              p["_sender"]["_client"].once("close", () => {
-                cb(T.unit)
-              })
-            })
-          )
-        )
-      )
+      M.make((p) => T.promise(() => p.shutdown()))
     )
   )
 

--- a/packages/otel-exporter-trace-otlp-grpc/src/index.ts
+++ b/packages/otel-exporter-trace-otlp-grpc/src/index.ts
@@ -38,23 +38,7 @@ export const makeTracingSpanExporter = M.gen(function* (_) {
   const spanExporter = yield* _(
     pipe(
       T.succeedWith(() => new OTLPTraceExporter(config)),
-      // NOTE Unfortunately this workaround/"hack" is currently needed since Otel doesn't yet provide a graceful
-      // way to shutdown.
-      //
-      // Related issue: https://github.com/open-telemetry/opentelemetry-js/issues/987
-      M.make((p) =>
-        T.gen(function* (_) {
-          while (1) {
-            yield* _(T.sleep(0))
-            const promises = p["_sendingPromises"] as any[]
-            if (promises.length > 0) {
-              yield* _(T.result(T.promise(() => Promise.all(promises))))
-            } else {
-              break
-            }
-          }
-        })
-      )
+      M.make((p) => T.promise(() => p.shutdown()))
     )
   )
 

--- a/packages/otel-exporter-trace-otlp-http/src/index.ts
+++ b/packages/otel-exporter-trace-otlp-http/src/index.ts
@@ -38,23 +38,7 @@ export const makeTracingSpanExporter = M.gen(function* (_) {
   const spanExporter = yield* _(
     pipe(
       T.succeedWith(() => new OTLPTraceExporter(config)),
-      // NOTE Unfortunately this workaround/"hack" is currently needed since Otel doesn't yet provide a graceful
-      // way to shutdown.
-      //
-      // Related issue: https://github.com/open-telemetry/opentelemetry-js/issues/987
-      M.make((p) =>
-        T.gen(function* (_) {
-          while (1) {
-            yield* _(T.sleep(0))
-            const promises = p["_sendingPromises"] as any[]
-            if (promises.length > 0) {
-              yield* _(T.result(T.promise(() => Promise.all(promises))))
-            } else {
-              break
-            }
-          }
-        })
-      )
+      M.make((p) => T.promise(() => p.shutdown()))
     )
   )
 


### PR DESCRIPTION
Should we also bump the `@opentelemetry` packages to a newer version? It's not clear to me what version fixed the issue. It looks like the `shutdown` function from the `SpanExporter` interface has always been returning a `Promise`. I wanted to refresh my mind about what exactly the issue is but it appears the youtube link of the video you recorded is not available anymore 😅


Fixes #285 